### PR TITLE
Mobile configuration service merge

### DIFF
--- a/mobile-config-service/.gitignore
+++ b/mobile-config-service/.gitignore
@@ -1,0 +1,11 @@
+/.idea
+/.gradle
+/logs
+/build
+*.jar
+*.class
+*.iml
+gradlew
+gradlew.bat
+settings.gradle
+mobile-config.yml

--- a/mobile-config-service/README.md
+++ b/mobile-config-service/README.md
@@ -1,0 +1,34 @@
+# mobile-config-service
+
+An API service with the [guidelines](https://github.com/Wikia/guidelines/tree/master/APIDesign) for Mobile Apps Team.
+
+The API provides modules configuration for mobile applications created in Wikia.
+
+## Usage
+
+To run the server:
+
+```bash
+cp mobile-config.yml.sample mobile-config.yml
+# launch the server
+gradle run
+```
+
+To check service health:
+```bash
+curl -v http://127.0.0.1:8081/healthcheck
+```
+A weird thing which I decided on is a health check for an external service. Our service strongly depends on it,
+so I found it beneficial to implement a health check of it. The health check is called `apps-deployer`
+and can be found on the list returned in a response above.
+
+To make a request from the server:
+```bash
+curl -v http://127.0.0.1:8080/configurations/platform/android/app/witcher
+```
+
+## License
+
+Copyright © 2014 Wikia
+
+Distributed under the Eclipse Public License either version 1.0 or (at your option) any later version.

--- a/mobile-config-service/build.gradle
+++ b/mobile-config-service/build.gradle
@@ -1,0 +1,32 @@
+apply plugin: 'java'
+apply plugin: 'application'
+sourceCompatibility = 1.8
+mainClassName = "com.wikia.mobileconfig.MobileConfigApplication"
+version = "0.1.0"
+
+repositories {
+    jcenter()
+    mavenCentral();
+}
+
+// In this section you declare the dependencies for your production and test code
+dependencies {
+    // The production code uses the SLF4J logging API at compile time
+    compile 'org.slf4j:slf4j-api:1.7.5'
+    compile 'io.dropwizard:dropwizard-core:0.7.1'
+    compile 'io.dropwizard:dropwizard-client:0.7.1'
+
+    // HAL stuff
+    compile 'com.theoryinpractise:halbuilder-standard:4.0.1'
+    compile ('com.theoryinpractise:halbuilder-jaxrs:1.1.1') {
+        exclude group: 'javax.ws.rs'
+    }
+
+    testCompile 'junit:junit:4.11'
+    testCompile 'io.dropwizard:dropwizard-testing:0.7.1'
+    testCompile 'org.mockito:mockito-core:1.9.5'
+}
+
+run {
+    args 'server', 'mobile-config.yml'
+}

--- a/mobile-config-service/mobile-config.yml.sample
+++ b/mobile-config-service/mobile-config.yml.sample
@@ -1,3 +1,6 @@
+appsDeployerDomain: domain-of-the-api-which-returns-apps-list
+cephDomain: domain-of-the-ceph-http-entry-point
+cephPort: 80
 httpClient:
   timeout: 7s
   connectionTimeout: 7s

--- a/mobile-config-service/mobile-config.yml.sample
+++ b/mobile-config-service/mobile-config.yml.sample
@@ -1,0 +1,22 @@
+httpClient:
+  timeout: 7s
+  connectionTimeout: 7s
+  timeToLive: 1h
+  cookiesEnabled: false
+  maxConnections: 1024
+  maxConnectionsPerRoute: 1024
+  keepAlive: 0ms
+  retries: 0
+  userAgent: mobile-config (dropwizard)
+logging:
+  level: INFO
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+    - type: file
+      threshold: INFO
+      currentLogFilename: /tmp/mobile-config.log
+      archivedLogFilenamePattern: /tmp/mobile-config-%d.log.gz
+      archivedFileCount: 5

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/MobileConfigApplication.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/MobileConfigApplication.java
@@ -1,0 +1,64 @@
+package com.wikia.mobileconfig;
+
+import com.wikia.mobileconfig.service.AppsDeployerList;
+import com.wikia.mobileconfig.service.FileConfigurationService;
+
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+
+import com.theoryinpractise.halbuilder.api.RepresentationFactory;
+import com.theoryinpractise.halbuilder.standard.StandardRepresentationFactory;
+import com.theoryinpractise.halbuilder.jaxrs.JaxRsHalBuilderSupport;
+
+import com.wikia.mobileconfig.resources.MobileConfigResource;
+import com.wikia.mobileconfig.health.MobileConfigHealthCheck;
+import com.wikia.mobileconfig.health.AppsDeployerHealthCheck;
+import com.wikia.mobileconfig.service.HttpConfigurationService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MobileConfigApplication extends Application<MobileConfigConfiguration> {
+
+  public static final RepresentationFactory
+      representationFactory =
+      new StandardRepresentationFactory();
+  public static final Logger logger = LoggerFactory.getLogger(FileConfigurationService.class);
+
+  public static void main(String[] args) throws Exception {
+    new MobileConfigApplication().run(args);
+  }
+
+  @Override
+  public String getName() {
+    return "mobile-config";
+  }
+
+  @Override
+  public void initialize(Bootstrap<MobileConfigConfiguration> bootstrap) {
+  }
+
+  @Override
+  public void run(MobileConfigConfiguration configuration, Environment environment) {
+    HttpConfigurationService configService = new HttpConfigurationService(
+        environment,
+        configuration
+    );
+    AppsDeployerList listService = new AppsDeployerList(environment, configuration);
+
+    final MobileConfigHealthCheck healthCheck = new MobileConfigHealthCheck();
+    environment.healthChecks().register("mobile-config", healthCheck);
+
+    final AppsDeployerHealthCheck
+        appsDeployerHealthCheck =
+        new AppsDeployerHealthCheck(listService);
+    environment.healthChecks().register("apps-deployer", appsDeployerHealthCheck);
+
+    final MobileConfigResource
+        mobileConfig =
+        new MobileConfigResource(configService, listService);
+    environment.jersey().register(mobileConfig);
+    environment.jersey().register(JaxRsHalBuilderSupport.class);
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/MobileConfigConfiguration.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/MobileConfigConfiguration.java
@@ -1,0 +1,50 @@
+package com.wikia.mobileconfig;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.client.HttpClientConfiguration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.NotEmpty;
+
+public class MobileConfigConfiguration extends Configuration {
+
+  @Valid
+  @NotNull
+  @JsonProperty
+  private HttpClientConfiguration httpClient;
+
+  @NotEmpty
+  @NotNull
+  private String appsDeployerDomain;
+
+  @NotEmpty
+  @NotNull
+  private String cephDomain;
+
+  @NotEmpty
+  @NotNull
+  private String cephPort;
+
+  public MobileConfigConfiguration() {
+    httpClient = new HttpClientConfiguration();
+  }
+
+  public HttpClientConfiguration getHttpClientConfiguration() {
+    return httpClient;
+  }
+
+  public String getAppsDeployerDomain() {
+    return appsDeployerDomain;
+  }
+
+  public String getCephDomain() {
+    return cephDomain;
+  }
+
+  public String getCephPort() {
+    return cephPort;
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/EmptyMobileConfiguration.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/EmptyMobileConfiguration.java
@@ -1,0 +1,11 @@
+package com.wikia.mobileconfig.core;
+
+import java.util.Collections;
+
+public class EmptyMobileConfiguration extends MobileConfiguration {
+
+  public EmptyMobileConfiguration() {
+    this.setModules(Collections.emptyList());
+  }
+
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/MobileConfiguration.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/MobileConfiguration.java
@@ -1,0 +1,16 @@
+package com.wikia.mobileconfig.core;
+
+import java.util.List;
+
+public class MobileConfiguration {
+
+  private List<Object> modules;
+
+  public List<Object> getModules() {
+    return modules;
+  }
+
+  public void setModules(List<Object> modules) {
+    this.modules = modules;
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/health/AppsDeployerHealthCheck.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/health/AppsDeployerHealthCheck.java
@@ -1,0 +1,24 @@
+package com.wikia.mobileconfig.health;
+
+import com.codahale.metrics.health.HealthCheck;
+
+import com.wikia.mobileconfig.service.AppsListService;
+
+public class AppsDeployerHealthCheck extends HealthCheck {
+
+  private final AppsListService service;
+  private static String CONNECTION_ERROR_MSG = "Cannot connect to apps-deployer-panel";
+
+  public AppsDeployerHealthCheck(AppsListService service) {
+    this.service = service;
+  }
+
+  @Override
+  protected Result check() throws Exception {
+    if (this.service.isUp()) {
+      return Result.healthy();
+    } else {
+      return Result.unhealthy(CONNECTION_ERROR_MSG);
+    }
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/health/MobileConfigHealthCheck.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/health/MobileConfigHealthCheck.java
@@ -1,0 +1,11 @@
+package com.wikia.mobileconfig.health;
+
+import com.codahale.metrics.health.HealthCheck;
+
+public class MobileConfigHealthCheck extends HealthCheck {
+
+  @Override
+  protected Result check() throws Exception {
+    return Result.healthy();
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/resources/MobileConfigResource.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/resources/MobileConfigResource.java
@@ -1,0 +1,60 @@
+package com.wikia.mobileconfig.resources;
+
+import com.codahale.metrics.annotation.Timed;
+
+import com.theoryinpractise.halbuilder.api.Representation;
+import com.theoryinpractise.halbuilder.api.RepresentationFactory;
+
+import com.wikia.mobileconfig.MobileConfigApplication;
+import com.wikia.mobileconfig.core.MobileConfiguration;
+import com.wikia.mobileconfig.service.ConfigurationService;
+import com.wikia.mobileconfig.service.AppsListService;
+
+import javax.ws.rs.*;
+
+import java.net.URISyntaxException;
+
+@Path("/configurations/platform/{platform}/app/{appTag}")
+@Produces(RepresentationFactory.HAL_JSON)
+public class MobileConfigResource {
+
+  private final ConfigurationService appConfiguration;
+  private final AppsListService appsList;
+
+  public MobileConfigResource(ConfigurationService configuration, AppsListService list) {
+    this.appConfiguration = configuration;
+    this.appsList = list;
+  }
+
+  /**
+   * GET /configurations/platform/{platform}/app/{appTag}
+   *
+   * @return Representation
+   */
+  @GET
+  @Timed
+  public Representation getMobileApplicationConfig(
+      @PathParam("platform") String platform,
+      @PathParam("appTag") String appTag
+  ) throws java.io.IOException, URISyntaxException {
+
+    if (!this.appsList.isValidAppTag(appTag)) {
+      //TODO: make it a cosher application/problem+json exception
+      throw new WebApplicationException(404);
+    }
+
+    MobileConfiguration configuration = this.appConfiguration.getConfiguration(platform, appTag);
+
+    if (configuration.getModules().isEmpty()) {
+      //TODO: make it a cosher application/problem+json exception
+      throw new WebApplicationException(404);
+    }
+
+    Representation rep = MobileConfigApplication.representationFactory.newRepresentation(
+        this.appConfiguration.createSelfUrl(platform, appTag)
+    ).withBean(configuration);
+
+    return rep;
+  }
+
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/AppsDeployerList.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/AppsDeployerList.java
@@ -1,0 +1,84 @@
+package com.wikia.mobileconfig.service;
+
+import com.wikia.mobileconfig.MobileConfigConfiguration;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.google.common.base.Optional;
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicResponseHandler;
+
+import io.dropwizard.client.HttpClientBuilder;
+import io.dropwizard.setup.Environment;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+public class AppsDeployerList implements AppsListService {
+
+  private static final String APPS_DEPLOYER_HEALTH_CHECK_URL_FORMAT = "http://%s/api/";
+  private static final String APPS_DEPLOYER_LIST_URL_FORMAT = "http://%s/api/app-configuration/";
+
+  private static String appsDeployerDomain;
+
+  private static final String
+      APPS_LIST_RESPONSE_ERROR_FORMAT = "Error, the response for %s is not valid!";
+
+  private final HttpClient httpClient;
+
+  public AppsDeployerList(Environment environment, MobileConfigConfiguration configuration) {
+    this.httpClient = new HttpClientBuilder(environment)
+        .using(configuration.getHttpClientConfiguration())
+        .build("apps-deployer-list-service");
+
+    this.appsDeployerDomain = configuration.getAppsDeployerDomain();
+  }
+
+  private List<HashMap<String, Object>> getAppsList() throws IOException {
+    String appsDeployerUrl = String.format(APPS_DEPLOYER_LIST_URL_FORMAT, appsDeployerDomain);
+    Optional<String> response = this.executeHttpRequest(appsDeployerUrl);
+    ObjectMapper mapper = new ObjectMapper();
+
+    if (response.isPresent()) {
+      return mapper.readValue(response.get(), new TypeReference<List<HashMap<String, Object>>>() {
+      });
+    } else {
+      throw new IllegalStateException(
+          String.format(APPS_LIST_RESPONSE_ERROR_FORMAT, appsDeployerUrl)
+      );
+    }
+  }
+
+  private Optional<String> executeHttpRequest(final String requestUrl) throws IOException {
+    HttpGet httpGet = new HttpGet(requestUrl);
+    ResponseHandler<String> responseHandler = new BasicResponseHandler();
+    return Optional.of(this.httpClient.execute(httpGet, responseHandler));
+  }
+
+  @Override
+  public Boolean isValidAppTag(String appTag) throws IOException {
+    List<HashMap<String, Object>> list = this.getAppsList();
+    return list.stream().filter(item -> item.values().contains(appTag)).findFirst().isPresent();
+  }
+
+  @Override
+  public Boolean isUp() throws IOException {
+    try {
+      String appsDeployerHealthCheckUrl = String.format(
+          APPS_DEPLOYER_HEALTH_CHECK_URL_FORMAT,
+          appsDeployerDomain
+      );
+      this.executeHttpRequest(appsDeployerHealthCheckUrl);
+
+      return true;
+    } catch (ClientProtocolException exception) {
+      return false;
+    }
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/AppsListService.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/AppsListService.java
@@ -1,0 +1,13 @@
+package com.wikia.mobileconfig.service;
+
+import java.io.IOException;
+
+/**
+ * A HTTP service interface for services which validate applications tags
+ */
+public interface AppsListService {
+
+  public Boolean isValidAppTag(String appTag) throws IOException;
+
+  public Boolean isUp() throws IOException;
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/ConfigurationService.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/ConfigurationService.java
@@ -1,0 +1,14 @@
+package com.wikia.mobileconfig.service;
+
+import com.wikia.mobileconfig.core.MobileConfiguration;
+
+import java.io.IOException;
+
+public interface ConfigurationService {
+
+  public MobileConfiguration getDefault(String platform) throws IOException;
+
+  public MobileConfiguration getConfiguration(String platform, String appTag) throws IOException;
+
+  public String createSelfUrl(String platform, String appTag);
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/ConfigurationServiceBase.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/ConfigurationServiceBase.java
@@ -1,0 +1,13 @@
+package com.wikia.mobileconfig.service;
+
+public abstract class ConfigurationServiceBase implements ConfigurationService {
+  private final static String CONFIGURATIONS_URL_FORMAT = "/configurations/platform/%s/app/%s";
+
+  protected final static String CONFIGURATION_NOT_FOUND_DEBUG_MESSAGE_FORMAT =
+      "Configuration for %s not found: falling back to default configuration for %s";
+
+  @Override
+  public String createSelfUrl(String platform, String appTag) {
+    return String.format(CONFIGURATIONS_URL_FORMAT, platform, appTag);
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/FileConfigurationService.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/FileConfigurationService.java
@@ -1,0 +1,65 @@
+package com.wikia.mobileconfig.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wikia.mobileconfig.core.MobileConfiguration;
+import com.wikia.mobileconfig.MobileConfigApplication;
+import com.wikia.mobileconfig.core.EmptyMobileConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * A class responsible for getting mobile applications' configuration from static files
+ */
+public class FileConfigurationService extends ConfigurationServiceBase {
+
+  private final static String CONFIGURATION_DEFAULT_PATH_FORMAT = "%s/%s:default.json";
+  private final static String CONFIGURATION_PATH_FORMAT = "%s/%s:%s.json";
+
+  private String root;
+  private ObjectMapper mapper;
+
+  public FileConfigurationService(String root) {
+    this.root = root;
+    this.mapper = new ObjectMapper();
+  }
+
+  @Override
+  public MobileConfiguration getDefault(String platform) throws IOException {
+    try {
+      return this.mapper.readValue(
+          new File(this.createDefaultFilePath(platform)),
+          MobileConfiguration.class
+      );
+    } catch (IOException e) {
+      return new EmptyMobileConfiguration();
+    }
+  }
+
+  @Override
+  public MobileConfiguration getConfiguration(String platform, String appTag) throws IOException {
+    try {
+      MobileConfiguration configuration = this.mapper.readValue(
+          new File(this.createFilePath(platform, appTag)),
+          MobileConfiguration.class
+      );
+
+      return configuration;
+    } catch (IOException e) {
+      MobileConfigApplication.logger.info(
+          String.format(CONFIGURATION_NOT_FOUND_DEBUG_MESSAGE_FORMAT, appTag, platform)
+      );
+
+      return getDefault(platform);
+    }
+  }
+
+  private String createDefaultFilePath(String platform) {
+    return String.format(CONFIGURATION_DEFAULT_PATH_FORMAT, this.root, platform);
+  }
+
+  private String createFilePath(String platform, String appTag) {
+    return String.format(CONFIGURATION_PATH_FORMAT, this.root, platform, appTag);
+  }
+
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/HttpConfigurationService.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/service/HttpConfigurationService.java
@@ -1,0 +1,84 @@
+package com.wikia.mobileconfig.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.wikia.mobileconfig.MobileConfigApplication;
+import com.wikia.mobileconfig.MobileConfigConfiguration;
+import com.wikia.mobileconfig.core.EmptyMobileConfiguration;
+import com.wikia.mobileconfig.core.MobileConfiguration;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicResponseHandler;
+
+import java.io.IOException;
+
+import io.dropwizard.client.HttpClientBuilder;
+import io.dropwizard.setup.Environment;
+
+/**
+ * A class responsible for getting mobile applications' configuration from our Ceph buckets via HTTP
+ */
+public class HttpConfigurationService extends ConfigurationServiceBase {
+
+  private static final String
+      CEPH_URL_FORMAT = "http://%s:%s/mobile-configuration-service/%s/%s/config.json";
+
+  private final HttpClient httpClient;
+  private final ObjectMapper mapper;
+  private final String cephDomain;
+  private final String cephPort;
+
+  public HttpConfigurationService(
+      Environment environment,
+      MobileConfigConfiguration configuration
+  ) {
+    this.httpClient = new HttpClientBuilder(environment)
+        .using(configuration.getHttpClientConfiguration())
+        .build("http-configuration-service");
+    this.mapper = new ObjectMapper();
+    this.cephDomain = configuration.getCephDomain();
+    this.cephPort = configuration.getCephPort();
+  }
+
+  @Override
+  public MobileConfiguration getDefault(String platform) throws IOException {
+    try {
+      return this.mapper.readValue(
+          this.executeHttpRequest(createCephUrl(platform, "_default")),
+          MobileConfiguration.class
+      );
+    } catch (IOException e) {
+      return new EmptyMobileConfiguration();
+    }
+  }
+
+  @Override
+  public MobileConfiguration getConfiguration(String platform, String appTag) throws IOException {
+    try {
+      MobileConfiguration configuration = this.mapper.readValue(
+          this.executeHttpRequest(createCephUrl(platform, appTag)),
+          MobileConfiguration.class
+      );
+
+      return configuration;
+    } catch (IOException e) {
+      MobileConfigApplication.logger.info(
+          String.format(CONFIGURATION_NOT_FOUND_DEBUG_MESSAGE_FORMAT, appTag, platform)
+      );
+
+      return getDefault(platform);
+    }
+  }
+
+  private String createCephUrl(String platform, String appTag) {
+    return String.format(CEPH_URL_FORMAT, cephDomain, cephPort, platform, appTag);
+  }
+
+  private String executeHttpRequest(final String requestUrl) throws IOException {
+    HttpGet httpGet = new HttpGet(requestUrl);
+    ResponseHandler<String> responseHandler = new BasicResponseHandler();
+    return this.httpClient.execute(httpGet, responseHandler);
+  }
+}

--- a/mobile-config-service/src/test/java/com/wikia/mobileconfig/IntegrationTest.java
+++ b/mobile-config-service/src/test/java/com/wikia/mobileconfig/IntegrationTest.java
@@ -1,0 +1,31 @@
+package com.wikia.mobileconfig;
+
+import com.sun.jersey.api.client.Client;
+import com.sun.jersey.api.client.ClientResponse;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import io.dropwizard.testing.junit.DropwizardAppRule;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class IntegrationTest {
+  @ClassRule
+  public static final DropwizardAppRule<MobileConfigConfiguration>
+      RULE = new DropwizardAppRule<MobileConfigConfiguration>(
+        MobileConfigApplication.class,
+        "mobile-config.yml"
+      );
+
+  @Test
+  public void unexistingResourceRespondsWith404() {
+    Client client = new Client();
+
+    ClientResponse response = client.resource(
+        String.format("http://localhost:%d/configurations/platform/test-platform/app/test-app/", RULE.getLocalPort()))
+        .get(ClientResponse.class);
+
+    assertThat(response.getStatus()).isEqualTo(404);
+  }
+}

--- a/mobile-config-service/src/test/java/com/wikia/mobileconfig/resources/MobileConfigResourceTest.java
+++ b/mobile-config-service/src/test/java/com/wikia/mobileconfig/resources/MobileConfigResourceTest.java
@@ -1,0 +1,102 @@
+package com.wikia.mobileconfig.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.jersey.api.client.UniformInterfaceException;
+
+import com.wikia.mobileconfig.core.EmptyMobileConfiguration;
+import com.wikia.mobileconfig.core.MobileConfiguration;
+import com.wikia.mobileconfig.service.AppsDeployerList;
+import com.wikia.mobileconfig.service.HttpConfigurationService;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.fest.assertions.api.Assertions.fail;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link MobileConfigResource}.
+ */
+public class MobileConfigResourceTest {
+
+  private static final AppsDeployerList appsListMock = mock(AppsDeployerList.class);
+  private static final HttpConfigurationService httpServiceMock = mock(
+      HttpConfigurationService.class
+  );
+
+  @ClassRule
+  public static final ResourceTestRule resources = ResourceTestRule.builder()
+      .addResource(new MobileConfigResource(httpServiceMock, appsListMock)).build();
+
+  @Test
+  public void getMobileApplicationConfigFails_invalidAppTag() throws IOException {
+    when(appsListMock.isValidAppTag("test-app")).thenReturn(false);
+
+    try {
+      resources.client()
+          .resource("/configurations/platform/test-platform/app/test-app")
+          .get(String.class);
+      fail("404 - missing invalid appTag exception");
+    } catch (Exception e) {
+      assert(e instanceof UniformInterfaceException);
+    }
+
+    verify(appsListMock, times(1)).isValidAppTag("test-app");
+    verify(httpServiceMock, never()).getConfiguration("test-platform", "test-app");
+    reset(appsListMock, httpServiceMock);
+  }
+
+  @Test
+  public void getMobileApplicationConfigFails_notFound() throws IOException {
+    when(appsListMock.isValidAppTag("test-app")).thenReturn(true);
+    when(httpServiceMock.getConfiguration("test-platform", "test-app"))
+        .thenReturn(new EmptyMobileConfiguration());
+    when(httpServiceMock.createSelfUrl("test-platform", "test-app"))
+        .thenReturn("/configurations/platform/test-platform/app/test-app");
+
+    try {
+      resources.client()
+        .resource("/configurations/platform/test-platform/app/test-app")
+        .get(String.class);
+      fail("404 - missing invalid modules exception");
+    } catch (Exception e) {
+      assert(e instanceof UniformInterfaceException);
+    }
+
+    verify(appsListMock).isValidAppTag("test-app");
+    verify(httpServiceMock).getConfiguration("test-platform", "test-app");
+    verify(httpServiceMock, never()).getDefault("test-platform");
+    reset(appsListMock, httpServiceMock);
+  }
+
+  @Test
+  public void getMobileApplicationConfigSuccess() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    MobileConfiguration cfgMock = mapper.readValue(
+        new File("src/test/resources/fixtures/test-platform:test-app.json"),
+        MobileConfiguration.class
+    );
+
+    when(appsListMock.isValidAppTag("test-app")).thenReturn(true);
+    when(httpServiceMock.createSelfUrl("test-platform", "test-app"))
+      .thenReturn("/configurations/platform/test-platform/app/test-app");
+    when(httpServiceMock.getConfiguration("test-platform", "test-app"))
+        .thenReturn(cfgMock);
+
+    resources.client()
+      .resource("/configurations/platform/test-platform/app/test-app")
+      .get(String.class);
+
+    //TODO: assert - the client response is our HAL object
+
+    verify(appsListMock).isValidAppTag("test-app");
+    verify(httpServiceMock).getConfiguration("test-platform", "test-app");
+    verify(httpServiceMock, never()).getDefault("test-platform");
+    reset(appsListMock, httpServiceMock);
+  }
+}

--- a/mobile-config-service/src/test/resources/fixtures/test-platform:test-app.json
+++ b/mobile-config-service/src/test/resources/fixtures/test-platform:test-app.json
@@ -1,0 +1,29 @@
+{
+  "modules": [
+    {
+      "type": "test",
+      "payload": {
+        "name": "dropwizard-test",
+        "url": "https://dropwizard.github.io/dropwizard/manual/testing.html"
+      },
+      "languages": ["java", "en"]
+    },
+    {
+      "type": "test",
+      "payload": {
+        "name": "phpunit-test",
+        "url": "https://phpunit.de/"
+      },
+      "languages": ["php", "en", "de"]
+    },
+    {
+      "type": "lib",
+      "payload": {
+        "name": "mockito",
+        "url": "http://site.mockito.org/",
+        "icon": "http://site.mockito.org/img/mockito-logo-small.svg"
+      },
+      "languages": ["en", "java", "javascript", "perl", "php", "python"]
+    }
+  ]
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,3 +27,5 @@ include 'pandora-examples'
 
 include 'pandora-gateways'
 
+include 'mobile-config-service'
+


### PR DESCRIPTION
Together with the Service/API Team we decided to merge Java services repos with our main pandora repo. This is a pull request in which it is happening.

**Why?**
It is a common trend and seems as good practice followed by "huge players" - we do not want to stay behind.

Second reason is to create libraries which will be useful for many other services. Once written in the repo will be easy to find and re-use.

We found out in the early state of services (Mobile Configuration Service and MercuryApi Service) keeping everything in one repository will be really helpful while refactoring code.

**Are you serious?!**
Yes, we are. But we are also aware of one downside of this solution: 1GB+ huge repository which needs to be cloned in example when new developer joins us. However, right now this repository is rather small and we want to give it a try. If we got to the size issue we will re-think this approach.

ping @drsnyder @jcellary @sqreek @nmonterroso @pchojnacki 