### PR TITLE
nobug Fixes a gradle config problem

### DIFF
--- a/pandora-api/build.gradle
+++ b/pandora-api/build.gradle
@@ -7,9 +7,6 @@ version = '1.0'
 repositories {
     jcenter()
     mavenCentral();
-
-    maven {
-    }
 }
 
 // In this section you declare the dependencies for your production and test code


### PR DESCRIPTION
This was preventing an import of the project into IntelliJ, because apparently the maven {} declaration requires a URL be present.