### PR TITLE
Fix the MWApi test by only mocking injected dependencies

### DIFF
--- a/mediawiki-fluent-api/src/test/java/com/wikia/mwapi/MWApiTest.java
+++ b/mediawiki-fluent-api/src/test/java/com/wikia/mwapi/MWApiTest.java
@@ -2,6 +2,12 @@ package com.wikia.mwapi;
 
 import com.wikia.mwapi.domain.ApiResponse;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import io.dropwizard.testing.FixtureHelpers;
 import org.junit.Test;
@@ -27,25 +33,37 @@ public class MWApiTest {
 
   @Test
   public void testGet() throws IOException {
-    MWApi mwApi = Mockito.mock(MWApi.class);
-    Mockito.when(mwApi.get()).thenCallRealMethod();
-    Mockito.when(mwApi.wikia(Mockito.anyString())).thenCallRealMethod();
-    Mockito.when(mwApi.queryAction()).thenCallRealMethod();
-    Mockito.when(mwApi.titles(Mockito.anyString())).thenCallRealMethod();
+    String wikia = "muppet";
+    String title = "Kermit the Frog";
+    String url = MWApi.createBuilder()
+        .wikia(wikia)
+        .queryAction()
+        .titles(title)
+        .url();
+    HttpUriRequest request = new HttpGet(url);
+
+    HttpClient httpClient = Mockito.mock(HttpClient.class);
+    HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
+    HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
 
     InputStream jsonStream = new ByteArrayInputStream(
         FixtureHelpers.fixture("fixtures/kermit-the-frog-title.json").getBytes(StandardCharsets.UTF_8)
     );
-    Mockito.when(mwApi.handleMWRequest(Mockito.anyString())).thenReturn(jsonStream);
+    Mockito.when(httpEntity.getContent()).thenReturn(jsonStream);
+    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
+    Mockito.when(httpClient.execute(Mockito.any(HttpUriRequest.class))).thenReturn(httpResponse);
 
-    ApiResponse response = mwApi
-        .wikia("muppet")
+    ApiResponse response = MWApi.createBuilder(httpClient)
+        .wikia(wikia)
         .queryAction()
-        .titles("Kermit the Frog")
+        .titles(title)
         .get();
     assertEquals("Kermit the Frog", response.getQuery().getFirstPage().getTitle());
     assertEquals(50, response.getQuery().getFirstPage().getPageId());
-  }
 
+    ArgumentCaptor<HttpUriRequest> argument = ArgumentCaptor.forClass(HttpUriRequest.class);
+    Mockito.verify(httpClient).execute(argument.capture());
+    assertEquals(url, argument.getValue().getURI().toString());
+  }
 
 }

--- a/mediawiki-fluent-api/src/test/java/com/wikia/mwapi/MWApiTest.java
+++ b/mediawiki-fluent-api/src/test/java/com/wikia/mwapi/MWApiTest.java
@@ -32,7 +32,7 @@ public class MWApiTest {
   }
 
   @Test
-  public void testGet() throws IOException {
+  public void testGetWithTitle() throws IOException {
     String wikia = "muppet";
     String title = "Kermit the Frog";
     String url = MWApi.createBuilder()
@@ -40,18 +40,8 @@ public class MWApiTest {
         .queryAction()
         .titles(title)
         .url();
-    HttpUriRequest request = new HttpGet(url);
 
-    HttpClient httpClient = Mockito.mock(HttpClient.class);
-    HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
-    HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
-
-    InputStream jsonStream = new ByteArrayInputStream(
-        FixtureHelpers.fixture("fixtures/kermit-the-frog-title.json").getBytes(StandardCharsets.UTF_8)
-    );
-    Mockito.when(httpEntity.getContent()).thenReturn(jsonStream);
-    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
-    Mockito.when(httpClient.execute(Mockito.any(HttpUriRequest.class))).thenReturn(httpResponse);
+    HttpClient httpClient = mockHttpClientForHandleMwRequest("fixtures/kermit-the-frog-title.json");
 
     ApiResponse response = MWApi.createBuilder(httpClient)
         .wikia(wikia)
@@ -64,6 +54,23 @@ public class MWApiTest {
     ArgumentCaptor<HttpUriRequest> argument = ArgumentCaptor.forClass(HttpUriRequest.class);
     Mockito.verify(httpClient).execute(argument.capture());
     assertEquals(url, argument.getValue().getURI().toString());
+  }
+
+
+  public HttpClient mockHttpClientForHandleMwRequest(String fixturePath) throws IOException {
+    HttpClient httpClient = Mockito.mock(HttpClient.class);
+    HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
+    HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
+
+    InputStream jsonStream = new ByteArrayInputStream(
+        FixtureHelpers.fixture(fixturePath).getBytes(StandardCharsets.UTF_8)
+    );
+
+    Mockito.when(httpEntity.getContent()).thenReturn(jsonStream);
+    Mockito.when(httpResponse.getEntity()).thenReturn(httpEntity);
+    Mockito.when(httpClient.execute(Mockito.any(HttpUriRequest.class))).thenReturn(httpResponse);
+
+    return httpClient;
   }
 
 }


### PR DESCRIPTION
This approach means that only the injected dependency is mocked which is preferred. The only issue with this approach is the inability to compare two `HttpUriRequest` objects with the same constructor input. Mockito provides a work around which allows you to capture the input and use that for verification purposes. There are [other ways to do this](http://docs.mockito.googlecode.com/hg/1.9.5/org/mockito/ArgumentMatcher.html) but I think this is the cleanest and simplest.

/cc @sqreek