### PR TITLE
Cosher HTTP errors

### DIFF
--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/EmptyMobileConfiguration.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/EmptyMobileConfiguration.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 public class EmptyMobileConfiguration extends MobileConfiguration {
 
   public EmptyMobileConfiguration() {
-    this.setModules(Collections.emptyList());
+    super(Collections.emptyList());
   }
 
 }

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/MobileConfiguration.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/MobileConfiguration.java
@@ -6,6 +6,9 @@ public class MobileConfiguration {
 
   private List<Object> modules;
 
+  public MobileConfiguration() {
+  }
+
   public MobileConfiguration(List<Object> modules) {
     this.modules = modules;
   }

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/MobileConfiguration.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/MobileConfiguration.java
@@ -6,11 +6,11 @@ public class MobileConfiguration {
 
   private List<Object> modules;
 
-  public List<Object> getModules() {
-    return modules;
+  public MobileConfiguration(List<Object> modules) {
+    this.modules = modules;
   }
 
-  public void setModules(List<Object> modules) {
-    this.modules = modules;
+  public List<Object> getModules() {
+    return modules;
   }
 }

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/Problem.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/core/Problem.java
@@ -1,0 +1,19 @@
+package com.wikia.mobileconfig.core;
+
+public class Problem {
+  private String title;
+  private String details;
+
+  public Problem(String title, String details) {
+    this.title = title;
+    this.details = details;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getDetails() {
+    return details;
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/ConfigurationNotFoundException.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/ConfigurationNotFoundException.java
@@ -1,0 +1,19 @@
+package com.wikia.mobileconfig.exceptions;
+
+import com.sun.jersey.api.Responses;
+import com.wikia.mobileconfig.core.Problem;
+
+import javax.ws.rs.core.Response;
+
+public class ConfigurationNotFoundException extends MobileConfigException {
+  static String EXCEPTION_MESSAGE_FORMAT = "Configuration for %s on %s could not be found";
+
+  public ConfigurationNotFoundException(String platform, String appTag) {
+    super(
+        Response.status(Responses.NOT_FOUND)
+            .entity(new Problem("Not found", String.format(EXCEPTION_MESSAGE_FORMAT, appTag, platform)))
+            .type(RESPONSE_TYPE)
+            .build()
+    );
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/InvalidApplicationTagException.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/InvalidApplicationTagException.java
@@ -1,0 +1,20 @@
+package com.wikia.mobileconfig.exceptions;
+
+import com.wikia.mobileconfig.core.Problem;
+
+import com.sun.jersey.api.Responses;
+
+import javax.ws.rs.core.Response;
+
+public class InvalidApplicationTagException extends MobileConfigException {
+  static String EXCEPTION_TITLE = "Invalid request";
+  static String EXCEPTION_MESSAGE_FORMAT = "Invalid application tag (%s)";
+
+  public InvalidApplicationTagException(String appTag) {
+    super(Response.status(Responses.CLIENT_ERROR)
+              .entity(new Problem(EXCEPTION_TITLE, String.format(EXCEPTION_MESSAGE_FORMAT, appTag)))
+              .type(RESPONSE_TYPE)
+              .build()
+    );
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/MobileConfigException.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/MobileConfigException.java
@@ -1,0 +1,12 @@
+package com.wikia.mobileconfig.exceptions;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+public abstract class MobileConfigException extends WebApplicationException {
+  static String RESPONSE_TYPE = "application/problem+json";
+
+  public MobileConfigException(Response exceptionResponse) {
+    super(exceptionResponse);
+  }
+}

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/resources/MobileConfigResource.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/resources/MobileConfigResource.java
@@ -7,11 +7,15 @@ import com.theoryinpractise.halbuilder.api.RepresentationFactory;
 
 import com.wikia.mobileconfig.MobileConfigApplication;
 import com.wikia.mobileconfig.core.MobileConfiguration;
+import com.wikia.mobileconfig.exceptions.ConfigurationNotFoundException;
 import com.wikia.mobileconfig.service.ConfigurationService;
 import com.wikia.mobileconfig.service.AppsListService;
 
 import javax.ws.rs.*;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 
 @Path("/configurations/platform/{platform}/app/{appTag}")
@@ -36,18 +40,17 @@ public class MobileConfigResource {
   public Representation getMobileApplicationConfig(
       @PathParam("platform") String platform,
       @PathParam("appTag") String appTag
-  ) throws java.io.IOException, URISyntaxException {
+  ) throws IOException, ConfigurationNotFoundException {
 
     if (!this.appsList.isValidAppTag(appTag)) {
       //TODO: make it a cosher application/problem+json exception
-      throw new WebApplicationException(404);
+      throw new WebApplicationException(new Exception("Invalid application"), 400);
     }
 
     MobileConfiguration configuration = this.appConfiguration.getConfiguration(platform, appTag);
 
     if (configuration.getModules().isEmpty()) {
-      //TODO: make it a cosher application/problem+json exception
-      throw new WebApplicationException(404);
+      throw new ConfigurationNotFoundException(platform, appTag);
     }
 
     Representation rep = MobileConfigApplication.representationFactory.newRepresentation(

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/resources/MobileConfigResource.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/resources/MobileConfigResource.java
@@ -9,6 +9,7 @@ import com.wikia.mobileconfig.MobileConfigApplication;
 import com.wikia.mobileconfig.core.MobileConfiguration;
 import com.wikia.mobileconfig.exceptions.ConfigurationNotFoundException;
 import com.wikia.mobileconfig.exceptions.InvalidApplicationTagException;
+import com.wikia.mobileconfig.exceptions.MobileConfigException;
 import com.wikia.mobileconfig.service.ConfigurationService;
 import com.wikia.mobileconfig.service.AppsListService;
 
@@ -38,7 +39,7 @@ public class MobileConfigResource {
   public Representation getMobileApplicationConfig(
       @PathParam("platform") String platform,
       @PathParam("appTag") String appTag
-  ) throws IOException, ConfigurationNotFoundException {
+  ) throws IOException, MobileConfigException {
 
     if (!this.appsList.isValidAppTag(appTag)) {
       throw new InvalidApplicationTagException(appTag);

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/resources/MobileConfigResource.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/resources/MobileConfigResource.java
@@ -8,15 +8,13 @@ import com.theoryinpractise.halbuilder.api.RepresentationFactory;
 import com.wikia.mobileconfig.MobileConfigApplication;
 import com.wikia.mobileconfig.core.MobileConfiguration;
 import com.wikia.mobileconfig.exceptions.ConfigurationNotFoundException;
+import com.wikia.mobileconfig.exceptions.InvalidApplicationTagException;
 import com.wikia.mobileconfig.service.ConfigurationService;
 import com.wikia.mobileconfig.service.AppsListService;
 
 import javax.ws.rs.*;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 
 @Path("/configurations/platform/{platform}/app/{appTag}")
 @Produces(RepresentationFactory.HAL_JSON)
@@ -43,8 +41,7 @@ public class MobileConfigResource {
   ) throws IOException, ConfigurationNotFoundException {
 
     if (!this.appsList.isValidAppTag(appTag)) {
-      //TODO: make it a cosher application/problem+json exception
-      throw new WebApplicationException(new Exception("Invalid application"), 400);
+      throw new InvalidApplicationTagException(appTag);
     }
 
     MobileConfiguration configuration = this.appConfiguration.getConfiguration(platform, appTag);


### PR DESCRIPTION
Mobile configuration service was returning so far blank pages with HTTP 400 and [HTTP 404](https://github.com/Wikia/pandora/compare/cosher-http-errors?expand=1#diff-a38472d5b4469546002d00ed0fbe868eL42) statuses in headers. [According to our API guidelines](https://github.com/Wikia/guidelines/tree/master/APIDesign#error-handling) it is supposed to return proper HTTP code statuses, `application/problem+json` type and an JSON object with `title` and `details`.

Changes below implements mentioned requirements.

//cc @drsnyder @jcellary @nmonterroso @sqreek @pchojnacki 