### PR TITLE
Upgrade to Dropwizard 0.8.0-rc2 and introduce integration tests separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,22 @@ about this project that’s a good place to start.
 
 ## Usage
 
+Launching unit tests:
+```bash
+./gradlew unitTest
+```
+
+Launching all tests:
+```bash
+./gradlew test
+```
+
 To run the server:
 
 ```bash
 cp pandora-examples/pandora.yaml.sample pandora-examples/pandora.yaml
 # launch the server
-gradle pandora-examples:run
+gradle pandora-service:run
 ```
 
 To make a request from the server:

--- a/build.gradle
+++ b/build.gradle
@@ -6,4 +6,8 @@ subprojects {
     apply plugin: 'java'
     sourceCompatibility = 1.8
     version = "0.1.0"
+
+    task unitTest(type: Test) {
+        exclude '**/integration/**'
+    }
 }

--- a/gradle/common_deps.gradle
+++ b/gradle/common_deps.gradle
@@ -1,6 +1,6 @@
 def sl4jVersion = "1.7.5"
 def junitVersion = "4.11"
-def mockitoVersion = "1.9.5"
+def mockitoVersion = "1.10.17"
 
 dependencies {
     // The production code uses the SLF4J logging API at compile time

--- a/gradle/pandora_common_deps.gradle
+++ b/gradle/pandora_common_deps.gradle
@@ -1,5 +1,5 @@
 apply from: rootProject.file('gradle/common_deps.gradle')
-def dropwizardVersion = "0.7.1"
+def dropwizardVersion = "0.8.0-rc2"
 
 dependencies {
     compile "io.dropwizard:dropwizard-core:$dropwizardVersion"
@@ -15,5 +15,6 @@ dependencies {
         exclude group: 'javax.ws.rs'
     }
 
+    testCompile 'org.easytesting:fest-assert-core:2.0M10'
     testCompile "io.dropwizard:dropwizard-testing:$dropwizardVersion"
 }

--- a/mobile-config-service/build.gradle
+++ b/mobile-config-service/build.gradle
@@ -13,40 +13,20 @@ buildscript {
     }
 }
 
-sourceCompatibility = 1.8
-mainClassName = "com.wikia.mobileconfig.MobileConfigApplication"
 version = "0.1.7"
+mainClassName = "com.wikia.mobileconfig.MobileConfigApplication"
+
 apply from: 'gradle/deployment.gradle'
+apply from: rootProject.file('gradle/pandora_common_deps.gradle')
 
 applicationDistribution.from("mobile-config.yml.sample") {
     rename 'mobile-config.yml.sample', "${project.name}.yml"
     into 'conf'
 }
 
-repositories {
-    jcenter()
-    mavenCentral();
-}
-
 // In this section you declare the dependencies for your production and test code
 dependencies {
-    //compile 'com.orbitz.consul:consul-client:0.8'
     compile 'com.github.dcshock:consul-rest-client:0.5'
-
-    // The production code uses the SLF4J logging API at compile time
-    compile 'org.slf4j:slf4j-api:1.7.5'
-    compile 'io.dropwizard:dropwizard-core:0.7.1'
-    compile 'io.dropwizard:dropwizard-client:0.7.1'
-
-    // HAL stuff
-    compile 'com.theoryinpractise:halbuilder-standard:4.0.1'
-    compile ('com.theoryinpractise:halbuilder-jaxrs:1.1.1') {
-        exclude group: 'javax.ws.rs'
-    }
-
-    testCompile 'junit:junit:4.11'
-    testCompile 'io.dropwizard:dropwizard-testing:0.7.1'
-    testCompile 'org.mockito:mockito-core:1.9.5'
 }
 
 run {

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/ConfigurationNotFoundException.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/ConfigurationNotFoundException.java
@@ -1,6 +1,5 @@
 package com.wikia.mobileconfig.exceptions;
 
-import com.sun.jersey.api.Responses;
 import com.wikia.mobileconfig.core.Problem;
 
 import javax.ws.rs.core.Response;
@@ -10,7 +9,7 @@ public class ConfigurationNotFoundException extends MobileConfigException {
 
   public ConfigurationNotFoundException(String platform, String appTag) {
     super(
-        Response.status(Responses.NOT_FOUND)
+        Response.status(Response.Status.NOT_FOUND)
             .entity(new Problem("Not found", String.format(EXCEPTION_MESSAGE_FORMAT, appTag, platform)))
             .type(RESPONSE_TYPE)
             .build()

--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/InvalidApplicationTagException.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/exceptions/InvalidApplicationTagException.java
@@ -2,8 +2,6 @@ package com.wikia.mobileconfig.exceptions;
 
 import com.wikia.mobileconfig.core.Problem;
 
-import com.sun.jersey.api.Responses;
-
 import javax.ws.rs.core.Response;
 
 public class InvalidApplicationTagException extends MobileConfigException {
@@ -11,7 +9,7 @@ public class InvalidApplicationTagException extends MobileConfigException {
   static String EXCEPTION_MESSAGE_FORMAT = "Invalid application tag (%s)";
 
   public InvalidApplicationTagException(String appTag) {
-    super(Response.status(Responses.CLIENT_ERROR)
+    super(Response.status(Response.Status.BAD_REQUEST)
               .entity(new Problem(EXCEPTION_TITLE, String.format(EXCEPTION_MESSAGE_FORMAT, appTag)))
               .type(RESPONSE_TYPE)
               .build()

--- a/mobile-config-service/src/test/java/com/wikia/mobileconfig/integration/IntegrationTest.java
+++ b/mobile-config-service/src/test/java/com/wikia/mobileconfig/integration/IntegrationTest.java
@@ -1,10 +1,14 @@
-package com.wikia.mobileconfig;
+package com.wikia.mobileconfig.integration;
 
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
+import com.wikia.mobileconfig.MobileConfigApplication;
+import com.wikia.mobileconfig.MobileConfigConfiguration;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Response;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
 
@@ -20,11 +24,12 @@ public class IntegrationTest {
 
   @Test
   public void unexistingResourceRespondsWith404() {
-    Client client = new Client();
+    Client client = ClientBuilder.newClient();
 
-    ClientResponse response = client.resource(
+    Response response = client.target(
         String.format("http://localhost:%d/configurations/platform/test-platform/app/test-app/", RULE.getLocalPort()))
-        .get(ClientResponse.class);
+        .request()
+        .get();
 
     assertThat(response.getStatus()).isEqualTo(404);
   }

--- a/pandora-gateways/src/main/java/com/wikia/pandora/gateway/mercury/MercuryGateway.java
+++ b/pandora-gateways/src/main/java/com/wikia/pandora/gateway/mercury/MercuryGateway.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;

--- a/pandora-service/src/main/java/com/wikia/pandora/service/mediawiki/MediawikiArticleService.java
+++ b/pandora-service/src/main/java/com/wikia/pandora/service/mediawiki/MediawikiArticleService.java
@@ -15,7 +15,8 @@ import com.wikia.pandora.domain.Revision;
 import com.wikia.pandora.domain.builder.PojoBuilderFactory;
 import com.wikia.pandora.gateway.mediawiki.MediawikiGateway;
 
-import org.apache.commons.lang.NotImplementedException;
+
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +40,7 @@ public class MediawikiArticleService extends MediawikiService implements Article
 
   @Override
   public ArticleWithDescription getArticleWithDescriptionByTitle(String wikia, String title) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override
@@ -57,12 +58,12 @@ public class MediawikiArticleService extends MediawikiService implements Article
 
   @Override
   public List<Comment> getArticleComments(String wikia, String title) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override
   public Comment getComment(String wikia, String title, Long commentId) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override

--- a/pandora-service/src/main/java/com/wikia/pandora/service/mediawiki/MediawikiServiceFactory.java
+++ b/pandora-service/src/main/java/com/wikia/pandora/service/mediawiki/MediawikiServiceFactory.java
@@ -4,10 +4,10 @@ import com.wikia.pandora.api.service.ArticleService;
 import com.wikia.pandora.api.service.CategoryService;
 import com.wikia.pandora.api.service.CommentService;
 import com.wikia.pandora.core.impl.configuration.PandoraConfiguration;
-import com.wikia.pandora.service.ServiceFactory;
 import com.wikia.pandora.gateway.mediawiki.MediawikiGateway;
+import com.wikia.pandora.service.ServiceFactory;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.http.client.HttpClient;
 
 import io.dropwizard.setup.Environment;
@@ -41,6 +41,6 @@ public class MediawikiServiceFactory extends ServiceFactory {
   @Override
   public CommentService createCommentService() {
 
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 }

--- a/pandora-service/src/main/java/com/wikia/pandora/service/mercury/MercuryArticlesService.java
+++ b/pandora-service/src/main/java/com/wikia/pandora/service/mercury/MercuryArticlesService.java
@@ -1,6 +1,5 @@
 package com.wikia.pandora.service.mercury;
 
-import com.sun.jersey.api.NotFoundException;
 import com.wikia.pandora.api.service.ArticleService;
 import com.wikia.pandora.domain.Article;
 import com.wikia.pandora.domain.ArticleWithContent;
@@ -13,12 +12,14 @@ import com.wikia.pandora.domain.User;
 import com.wikia.pandora.domain.builder.PojoBuilderFactory;
 import com.wikia.pandora.gateway.mercury.MercuryGateway;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import javax.ws.rs.NotFoundException;
 
 public class MercuryArticlesService extends MercuryService implements ArticleService {
 
@@ -47,12 +48,12 @@ public class MercuryArticlesService extends MercuryService implements ArticleSer
 
   @Override
   public ArticleWithDescription getArticleWithDescriptionByTitle(String wikia, String title) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override
   public ArticleWithContent getArticleWithContentByTitle(String wikia, String title) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override
@@ -95,26 +96,26 @@ public class MercuryArticlesService extends MercuryService implements ArticleSer
 
   @Override
   public List<Article> getArticlesFromWikia(String wikia) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override
   public List<Category> getArticleCategories(String wikia, String title) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override
   public List<Media> getArticleMedia(String wikia, String title) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override
   public List<Revision> getArticleRevisions(String wikia, String title) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override
   public List<User> getArticleContributors(String wikia, String title) {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 }

--- a/pandora-service/src/main/java/com/wikia/pandora/service/mercury/MercuryServiceFactory.java
+++ b/pandora-service/src/main/java/com/wikia/pandora/service/mercury/MercuryServiceFactory.java
@@ -8,7 +8,7 @@ import com.wikia.pandora.core.impl.configuration.PandoraConfiguration;
 import com.wikia.pandora.service.ServiceFactory;
 import com.wikia.pandora.gateway.mercury.MercuryGateway;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.http.client.HttpClient;
 
 import io.dropwizard.client.HttpClientBuilder;
@@ -30,12 +30,12 @@ public class MercuryServiceFactory extends ServiceFactory {
 
   @Override
   public CategoryService createCategoryService() {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   @Override
   public CommentService createCommentService() {
-    throw new NotImplementedException();
+    throw new NotImplementedException("");
   }
 
   private HttpClient createHttpClient(String name) {


### PR DESCRIPTION
Dropwizard 0.7.1 uses old jersey libraries which caused me a lot headache when trying to use some existing consul libraries.
My proposal is to upgrade to version 0.8.0-rc2 since Dropwizard is 'mostly' a glue between many existing libraries and in my opinion something tagged as RC-2 is generally considered stable.

Documentation for 0.8.0-rc2 can be found at
http://dropwizard.io/0.8.0-rc2/docs/manual/testing.html

@jcellary @drsnyder @nandy-andy @nmonterroso @sqreek 