### PR TITLE
Update the nirvana-api README with dependencies

### DIFF
--- a/nirvana-api/README.md
+++ b/nirvana-api/README.md
@@ -34,3 +34,14 @@ try {
 
 // do stuff with cr
 ```
+
+## Dependencies
+
+To use the code generation utility you will need `gradle` and `mvn` (Maven)
+installed locally. To do so on OS X using homebrew, do the following:
+
+```sh
+brew update
+brew install maven
+brew install gradle
+```


### PR DESCRIPTION
A minor change to the nirvana-api to list the dependencies. I needed to install maven before I could get the build to start.

/cc @nmonterroso 