### PR TITLE
Adding InfluxDbReporterFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /classes
 /checkouts
 /logs
+rebel.xml
 pom.xml
 pom.xml.asc
 *.class

--- a/pandora-core/build.gradle
+++ b/pandora-core/build.gradle
@@ -4,4 +4,5 @@ dependencies {
     compile('com.orbitz.consul:consul-client:0.8') {
         exclude group: 'org.apache.cxf'
     }
+    compile 'net.alchim31:metrics-influxdb:0.6.0'
 }

--- a/pandora-core/src/main/java/com/wikia/pandora/core/metrics/InfluxDbReporterFactory.java
+++ b/pandora-core/src/main/java/com/wikia/pandora/core/metrics/InfluxDbReporterFactory.java
@@ -1,0 +1,90 @@
+package com.wikia.pandora.core.metrics;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+import javax.validation.constraints.NotNull;
+
+import io.dropwizard.metrics.BaseFormattedReporterFactory;
+import metrics_influxdb.InfluxdbReporter;
+import metrics_influxdb.InfluxdbUdp;
+
+@JsonTypeName("influxdb")
+public class InfluxDbReporterFactory extends BaseFormattedReporterFactory {
+  @NotNull
+  private String host;
+
+  @NotNull
+  private int port;
+
+  @NotNull
+  private String prefix;
+
+  private boolean skipIdleMetrics = true;
+
+  @JsonProperty
+  public String getHost() {
+    return host;
+  }
+
+  @JsonProperty
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  @JsonProperty
+  public int getPort() {
+    return port;
+  }
+
+  @JsonProperty
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  @JsonProperty
+  public String getPrefix() {
+    return prefix;
+  }
+
+  @JsonProperty
+  public void setPrefix(String prefix) {
+    this.prefix = prefix;
+  }
+
+  @JsonProperty
+  public boolean getSkipIdleMetrics() {
+    return skipIdleMetrics;
+  }
+
+  @JsonProperty
+  public void setSkipIdleMetrics(boolean skipIdleMetrics) {
+    this.skipIdleMetrics = skipIdleMetrics;
+  }
+
+  @Override
+  public MetricFilter getFilter() {
+    return new RegexFilter(getIncludes(), getExcludes());
+  }
+
+  public ScheduledReporter build(MetricRegistry registry) {
+    InfluxdbUdp influxdb = new InfluxdbUdp(getHost(), getPort());
+    return InfluxdbReporter
+        .forRegistry(registry)
+        .prefixedWith(getPrefix())
+        .convertRatesTo(getRateUnit())
+        .convertDurationsTo(getDurationUnit())
+        .filter(getFilter())
+        .skipIdleMetrics(getSkipIdleMetrics())
+        .build(influxdb);
+  }
+}

--- a/pandora-core/src/main/java/com/wikia/pandora/core/metrics/RegexFilter.java
+++ b/pandora-core/src/main/java/com/wikia/pandora/core/metrics/RegexFilter.java
@@ -1,0 +1,62 @@
+package com.wikia.pandora.core.metrics;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+public class RegexFilter implements MetricFilter {
+  private ArrayList<Pattern> includes;
+  private ArrayList<Pattern> excludes;
+
+  public RegexFilter(ImmutableSet<String> includes, ImmutableSet<String> excludes) {
+    this.includes = compilePatterns(includes);
+    this.excludes = compilePatterns(excludes);
+  }
+
+  private ArrayList<Pattern> compilePatterns(ImmutableSet<String> patternStrings) {
+    ArrayList<Pattern> patterns = new ArrayList<>();
+    patternStrings.forEach(s -> patterns.add(Pattern.compile(s)));
+
+    return patterns;
+  }
+
+  private boolean includesMatches(String name) {
+    for (Pattern p : includes) {
+      if (p.matcher(name).matches()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private boolean excludesMatches(String name) {
+    for (Pattern p : excludes) {
+      if (p.matcher(name).matches()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean matches(String name, Metric metric) {
+    boolean useInclude = !includes.isEmpty();
+    boolean useExclude = !excludes.isEmpty();
+
+    if (useInclude && useExclude) {
+      return includesMatches(name) || !excludesMatches(name);
+    } else if (useInclude && !useExclude) {
+      return includesMatches(name);
+    } else if (!useInclude && useExclude) {
+      return excludesMatches(name);
+    }
+
+    return true;
+  }
+}

--- a/pandora-core/src/main/resources/META-INF/services/io.dropwizard.metrics.ReporterFactory
+++ b/pandora-core/src/main/resources/META-INF/services/io.dropwizard.metrics.ReporterFactory
@@ -1,0 +1,1 @@
+com.wikia.pandora.core.metrics.InfluxDbReporterFactory


### PR DESCRIPTION
@Wikia/platform-team 
https://wikia-inc.atlassian.net/browse/SERVICES-59

This introduces the InfluxDbReporterFactory discoverable so that the `InfluxDbReporter` in the [metrics-influxdb](https://github.com/davidB/metrics-influxdb) library can be used in the mobile-config-service project for sending response times and other metric data to InfluxDB. I've documented config/usage [on the pandora wiki](https://github.com/Wikia/pandora/wiki/Sending-Metrics-to-InfluxDB)