### PR TITLE
add cobertura plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ subprojects {
         mavenCentral();
     }
     apply plugin: 'java'
+    apply from: "${parent.projectDir.canonicalPath}/gradle/cobertura.gradle"
     sourceCompatibility = 1.8
     version = "0.1.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ subprojects {
         mavenCentral();
     }
     apply plugin: 'java'
-    apply from: "${parent.projectDir.canonicalPath}/gradle/cobertura.gradle"
+    apply from: rootProject.file("gradle/cobertura.gradle")
     sourceCompatibility = 1.8
     version = "0.1.0"
 

--- a/gradle/cobertura.gradle
+++ b/gradle/cobertura.gradle
@@ -1,0 +1,53 @@
+logger.info "Configuring Cobertura Plugin"
+
+configurations{
+    coberturaRuntime {extendsFrom testRuntime}
+}
+
+dependencies {
+    coberturaRuntime 'net.sourceforge.cobertura:cobertura:1.9.4'
+}
+
+def serFile="${project.buildDir}/cobertura.ser"
+def classes="${project.buildDir}/classes/main"
+def classesCopy="${classes}-copy"
+
+
+task cobertura(type: Test){
+    dependencies {
+        testRuntime 'net.sourceforge.cobertura:cobertura:2.0.3'
+    }
+
+    systemProperty "net.sourceforge.cobertura.datafile", serFile
+    exclude '**/integration/**'
+
+}
+
+cobertura.doFirst  {
+    logger.quiet "Instrumenting classes for Cobertura"
+    ant {
+        delete(file:serFile, failonerror:false)
+        delete(dir: classesCopy, failonerror:false)
+        copy(todir: classesCopy) { fileset(dir: classes) }
+
+        taskdef(resource:'tasks.properties', classpath: configurations.coberturaRuntime.asPath)
+        'cobertura-instrument'(datafile: serFile) {
+            fileset(dir: classes,
+                    includes:"**/*.class",
+                    excludes:"**/*Test.class")
+        }
+    }
+}
+
+cobertura.doLast{
+    if (new File(classesCopy).exists()) {
+        //create html cobertura report
+        ant.'cobertura-report'(destdir:"${project.reportsDir}/cobertura",
+                               format:'html', srcdir:"src/main/java", datafile: serFile)
+        //create xml cobertura report
+        ant.'cobertura-report'(destdir:"${project.reportsDir}/cobertura",
+                               format:'xml', srcdir:"src/main/java", datafile: serFile)
+        ant.delete(file: classes)
+        ant.move(file: classesCopy, tofile: classes)
+    }
+}


### PR DESCRIPTION
Add gradle task for cobertura.
I realy don't know why it is work only when coberturaRuntime and dependencies has 2 different version.
when both have 1.9.4, there is error while compile (not working at java 1.8 issue solved in later versions)
when both have 2.0.3 compile error does not appear, but no coverage was done. The cobertura.xml file was created but without any data.
