### PR TITLE
refactor RegexFilter, add unit tests to RegexFilter

### DIFF
--- a/pandora-core/src/main/java/com/wikia/pandora/core/metrics/InfluxDbReporterFactory.java
+++ b/pandora-core/src/main/java/com/wikia/pandora/core/metrics/InfluxDbReporterFactory.java
@@ -1,16 +1,10 @@
 package com.wikia.pandora.core.metrics;
 
-import com.google.common.collect.ImmutableSet;
-
-import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-
-import java.util.HashMap;
-import java.util.concurrent.TimeUnit;
 
 import javax.validation.constraints.NotNull;
 
@@ -20,6 +14,7 @@ import metrics_influxdb.InfluxdbUdp;
 
 @JsonTypeName("influxdb")
 public class InfluxDbReporterFactory extends BaseFormattedReporterFactory {
+
   @NotNull
   private String host;
 
@@ -30,6 +25,8 @@ public class InfluxDbReporterFactory extends BaseFormattedReporterFactory {
   private String prefix;
 
   private boolean skipIdleMetrics = true;
+
+  private boolean excludeTakesPrecedence = false;
 
   @JsonProperty
   public String getHost() {
@@ -71,9 +68,19 @@ public class InfluxDbReporterFactory extends BaseFormattedReporterFactory {
     this.skipIdleMetrics = skipIdleMetrics;
   }
 
+  @JsonProperty
+  public boolean getExcludeTakesPrecedence() {
+    return excludeTakesPrecedence;
+  }
+
+  @JsonProperty
+  public void setExcludeTakesPrecedence(boolean excludeTakesPrecedence) {
+    this.excludeTakesPrecedence = excludeTakesPrecedence;
+  }
+
   @Override
   public MetricFilter getFilter() {
-    return new RegexFilter(getIncludes(), getExcludes());
+    return new RegexFilter(getIncludes(), getExcludes(), getExcludeTakesPrecedence());
   }
 
   public ScheduledReporter build(MetricRegistry registry) {

--- a/pandora-core/src/main/java/com/wikia/pandora/core/metrics/RegexFilter.java
+++ b/pandora-core/src/main/java/com/wikia/pandora/core/metrics/RegexFilter.java
@@ -5,58 +5,67 @@ import com.google.common.collect.ImmutableSet;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 
-import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 public class RegexFilter implements MetricFilter {
-  private ArrayList<Pattern> includes;
-  private ArrayList<Pattern> excludes;
+
+  private Pattern includes;
+  private Pattern excludes;
+  private boolean excludeFromInclude;
 
   public RegexFilter(ImmutableSet<String> includes, ImmutableSet<String> excludes) {
+    this(includes, excludes, false);
+  }
+
+  /**
+   * @param includes           includes patterns
+   * @param excludes           excludes patterns
+   * @param excludeFromInclude if true, exclude from include, if false include from exclude
+   */
+  public RegexFilter(ImmutableSet<String> includes, ImmutableSet<String> excludes,
+                     boolean excludeFromInclude) {
+    this.excludeFromInclude = excludeFromInclude;
     this.includes = compilePatterns(includes);
     this.excludes = compilePatterns(excludes);
   }
 
-  private ArrayList<Pattern> compilePatterns(ImmutableSet<String> patternStrings) {
-    ArrayList<Pattern> patterns = new ArrayList<>();
-    patternStrings.forEach(s -> patterns.add(Pattern.compile(s)));
-
-    return patterns;
+  private Pattern compilePatterns(ImmutableSet<String> patternStrings) {
+    Pattern pattern = null;
+    if (patternStrings != null && !patternStrings.isEmpty()) {
+      String combinePattern = String.join("|", patternStrings);
+      pattern = Pattern.compile(combinePattern);
+    }
+    return pattern;
   }
 
   private boolean includesMatches(String name) {
-    for (Pattern p : includes) {
-      if (p.matcher(name).matches()) {
-        return true;
-      }
-    }
-
-    return false;
+    return includes.matcher(name).matches();
   }
 
   private boolean excludesMatches(String name) {
-    for (Pattern p : excludes) {
-      if (p.matcher(name).matches()) {
-        return true;
-      }
-    }
-
-    return false;
+    return excludes.matcher(name).matches();
   }
 
   @Override
   public boolean matches(String name, Metric metric) {
-    boolean useInclude = !includes.isEmpty();
-    boolean useExclude = !excludes.isEmpty();
+    boolean useInclude = (includes != null);
+    boolean useExclude = (excludes != null);
 
     if (useInclude && useExclude) {
-      return includesMatches(name) || !excludesMatches(name);
-    } else if (useInclude && !useExclude) {
+      return matchesWithExcludeMethod(name);
+    } else if (useInclude) {
       return includesMatches(name);
-    } else if (!useInclude && useExclude) {
-      return excludesMatches(name);
+    } else if (useExclude) {
+      return !excludesMatches(name);
     }
-
     return true;
+  }
+
+  private boolean matchesWithExcludeMethod(String name) {
+    if (excludeFromInclude) {
+      return includesMatches(name) && !excludesMatches(name);
+    } else {
+      return includesMatches(name) || !excludesMatches(name);
+    }
   }
 }

--- a/pandora-core/src/main/java/com/wikia/pandora/core/metrics/RegexFilter.java
+++ b/pandora-core/src/main/java/com/wikia/pandora/core/metrics/RegexFilter.java
@@ -20,7 +20,10 @@ public class RegexFilter implements MetricFilter {
   /**
    * @param includes           includes patterns
    * @param excludes           excludes patterns
-   * @param excludeFromInclude if true, exclude from include, if false include from exclude
+   * @param excludeFromInclude if false, all metrics are reported, except those matching a pattern
+   *                           in excludes, unless they also match a pattern in includes. If true,
+   *                           only metrics matching include patterns are reported, unless they also
+   *                           match pattern in excludes
    */
   public RegexFilter(ImmutableSet<String> includes, ImmutableSet<String> excludes,
                      boolean excludeFromInclude) {

--- a/pandora-core/src/main/java/com/wikia/pandora/core/metrics/RegexFilter.java
+++ b/pandora-core/src/main/java/com/wikia/pandora/core/metrics/RegexFilter.java
@@ -11,23 +11,23 @@ public class RegexFilter implements MetricFilter {
 
   private Pattern includes;
   private Pattern excludes;
-  private boolean excludeFromInclude;
+  private boolean excludeTakesPrecedence;
 
   public RegexFilter(ImmutableSet<String> includes, ImmutableSet<String> excludes) {
     this(includes, excludes, false);
   }
 
   /**
-   * @param includes           includes patterns
-   * @param excludes           excludes patterns
-   * @param excludeFromInclude if false, all metrics are reported, except those matching a pattern
-   *                           in excludes, unless they also match a pattern in includes. If true,
-   *                           only metrics matching include patterns are reported, unless they also
-   *                           match pattern in excludes
+   * @param includes               includes patterns
+   * @param excludes               excludes patterns
+   * @param excludeTakesPrecedence if true, all metrics are reported, except those matching a
+   *                               pattern in excludes, unless they also match a pattern in
+   *                               includes. If false, only metrics matching include patterns are
+   *                               reported, unless they also match pattern in excludes
    */
   public RegexFilter(ImmutableSet<String> includes, ImmutableSet<String> excludes,
-                     boolean excludeFromInclude) {
-    this.excludeFromInclude = excludeFromInclude;
+                     boolean excludeTakesPrecedence) {
+    this.excludeTakesPrecedence = excludeTakesPrecedence;
     this.includes = compilePatterns(includes);
     this.excludes = compilePatterns(excludes);
   }
@@ -65,10 +65,10 @@ public class RegexFilter implements MetricFilter {
   }
 
   private boolean matchesWithExcludeMethod(String name) {
-    if (excludeFromInclude) {
-      return includesMatches(name) && !excludesMatches(name);
-    } else {
+    if (excludeTakesPrecedence) {
       return includesMatches(name) || !excludesMatches(name);
+    } else {
+      return includesMatches(name) && !excludesMatches(name);
     }
   }
 }

--- a/pandora-core/src/test/java/com/wikia/pandora/core/metrics/RegexFilterTest.java
+++ b/pandora-core/src/test/java/com/wikia/pandora/core/metrics/RegexFilterTest.java
@@ -93,8 +93,22 @@ public class RegexFilterTest {
     RegexFilter regexFilter = new RegexFilter(includes, excludes, true);
 
     assertTrue(regexFilter.matches("abcdef12", null));
-    
+
     assertFalse(regexFilter.matches("12", null));
     assertFalse(regexFilter.matches("abcde12", null));
+  }
+
+  @Test
+  public void testMatchesWithoutIncludeOrExclude() {
+    RegexFilter regexFilter = new RegexFilter(null, null);
+
+    assertTrue(regexFilter.matches("abcdef", null));
+    assertTrue(regexFilter.matches("4567", null));
+    assertTrue(regexFilter.matches("", null));
+    assertTrue(regexFilter.matches("abcde", null));
+    assertTrue(regexFilter.matches("simple", null));
+    assertTrue(regexFilter.matches("test09", null));
+    assertTrue(regexFilter.matches("012", null));
+
   }
 }

--- a/pandora-core/src/test/java/com/wikia/pandora/core/metrics/RegexFilterTest.java
+++ b/pandora-core/src/test/java/com/wikia/pandora/core/metrics/RegexFilterTest.java
@@ -1,0 +1,100 @@
+package com.wikia.pandora.core.metrics;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import javax.validation.constraints.AssertTrue;
+
+import static org.junit.Assert.*;
+
+public class RegexFilterTest {
+
+  @Test
+  public void testIncludeMatches() throws Exception {
+    ImmutableSet<String> includes = new ImmutableSet.Builder<String>()
+        .add("([a-z]){5}")
+        .add("([0-4]){3}")
+        .add("simple")
+        .add("([a-z]+)[0-9]{2}")
+        .build();
+
+    RegexFilter regexFilter = new RegexFilter(includes, null);
+
+    assertTrue(regexFilter.matches("abcde", null));
+    assertTrue(regexFilter.matches("simple", null));
+    assertTrue(regexFilter.matches("test09", null));
+    assertTrue(regexFilter.matches("012", null));
+
+    assertFalse(regexFilter.matches("abcdef", null));
+    assertFalse(regexFilter.matches("4567", null));
+    assertFalse(regexFilter.matches("", null));
+  }
+
+
+  @Test
+  public void testExcludeMatches() throws Exception {
+    ImmutableSet<String> excludes = new ImmutableSet.Builder<String>()
+        .add("([a-z]){5}")
+        .add("([0-4]){3}")
+        .add("simple")
+        .add("([a-z]+)[0-9]{2}")
+        .build();
+
+    RegexFilter regexFilter = new RegexFilter(null, excludes);
+
+    assertTrue(regexFilter.matches("abcdef", null));
+    assertTrue(regexFilter.matches("4567", null));
+    assertTrue(regexFilter.matches("", null));
+
+    assertFalse(regexFilter.matches("abcde", null));
+    assertFalse(regexFilter.matches("simple", null));
+    assertFalse(regexFilter.matches("test09", null));
+    assertFalse(regexFilter.matches("012", null));
+
+  }
+
+  @Test
+  public void testIncludeFromExcludeMatches() throws Exception {
+    ImmutableSet<String> includes = new ImmutableSet.Builder<String>()
+        .add("([a-z]){5}[0-9]{2}")
+        .add("([0-4]){2}")
+        .build();
+    ImmutableSet<String> excludes = new ImmutableSet.Builder<String>()
+        .add("([a-z])+[0-9]{2}")
+        .add("([0-9]+)")
+        .build();
+
+    RegexFilter regexFilter = new RegexFilter(includes, excludes);
+
+    assertTrue(regexFilter.matches("abcde12", null));
+    assertTrue(regexFilter.matches("12", null));
+
+    assertFalse(regexFilter.matches("abcdef12", null));
+  }
+
+  @Test
+  public void testExcludeFromIncludeMatches() throws Exception {
+    ImmutableSet<String> includes = new ImmutableSet.Builder<String>()
+        .add("([a-z]+)[0-9]{2}")
+        .add("([0-9]+)")
+        .build();
+    ImmutableSet<String> excludes = new ImmutableSet.Builder<String>()
+        .add("([a-z]){5}[0-9]{2}")
+        .add("([0-4]){2}")
+        .build();
+
+    RegexFilter regexFilter = new RegexFilter(includes, excludes, true);
+
+    assertTrue(regexFilter.matches("abcdef12", null));
+    
+    assertFalse(regexFilter.matches("12", null));
+    assertFalse(regexFilter.matches("abcde12", null));
+  }
+}

--- a/pandora-core/src/test/java/com/wikia/pandora/core/metrics/RegexFilterTest.java
+++ b/pandora-core/src/test/java/com/wikia/pandora/core/metrics/RegexFilterTest.java
@@ -57,11 +57,10 @@ public class RegexFilterTest {
     assertFalse(regexFilter.matches("simple", null));
     assertFalse(regexFilter.matches("test09", null));
     assertFalse(regexFilter.matches("012", null));
-
   }
 
   @Test
-  public void testIncludeFromExcludeMatches() throws Exception {
+  public void testExcludeTakesPrecedenceMatches() throws Exception {
     ImmutableSet<String> includes = new ImmutableSet.Builder<String>()
         .add("([a-z]){5}[0-9]{2}")
         .add("([0-4]){2}")
@@ -71,7 +70,7 @@ public class RegexFilterTest {
         .add("([0-9]+)")
         .build();
 
-    RegexFilter regexFilter = new RegexFilter(includes, excludes);
+    RegexFilter regexFilter = new RegexFilter(includes, excludes, true);
 
     assertTrue(regexFilter.matches("abcde12", null));
     assertTrue(regexFilter.matches("12", null));
@@ -80,7 +79,7 @@ public class RegexFilterTest {
   }
 
   @Test
-  public void testExcludeFromIncludeMatches() throws Exception {
+  public void testIncludeTakesPrecedenceMatches() throws Exception {
     ImmutableSet<String> includes = new ImmutableSet.Builder<String>()
         .add("([a-z]+)[0-9]{2}")
         .add("([0-9]+)")
@@ -90,7 +89,7 @@ public class RegexFilterTest {
         .add("([0-4]){2}")
         .build();
 
-    RegexFilter regexFilter = new RegexFilter(includes, excludes, true);
+    RegexFilter regexFilter = new RegexFilter(includes, excludes, false);
 
     assertTrue(regexFilter.matches("abcdef12", null));
 
@@ -99,7 +98,7 @@ public class RegexFilterTest {
   }
 
   @Test
-  public void testMatchesWithoutIncludeOrExclude() {
+  public void testMatchesWithoutIncludesOrExcludes() {
     RegexFilter regexFilter = new RegexFilter(null, null);
 
     assertTrue(regexFilter.matches("abcdef", null));
@@ -109,6 +108,5 @@ public class RegexFilterTest {
     assertTrue(regexFilter.matches("simple", null));
     assertTrue(regexFilter.matches("test09", null));
     assertTrue(regexFilter.matches("012", null));
-
   }
 }


### PR DESCRIPTION
Simplifier RegexFilter
Add null option instead empty ImmutableSet
Add excludeFromInclude option to explicit behaviour
Use one Pattern combine with | (pipe) instead of pattern list
Add unit tests

When adding tests to regexFilter I found logical [mistake](https://github.com/Wikia/pandora/compare/Add_unit_test_to_regex_filter?expand=1#diff-16d09b474e40661297ae6608ba025619L57), and [inconsistent in logic](https://github.com/Wikia/pandora/compare/Add_unit_test_to_regex_filter?expand=1#diff-16d09b474e40661297ae6608ba025619L53) (no explicit is exclude excludes from includes or vice versa)

//cc @nmonterroso 