### PR TITLE
allow consulConfig to be null in application.yaml

### DIFF
--- a/mobile-config-service/src/main/java/com/wikia/mobileconfig/MobileConfigConfiguration.java
+++ b/mobile-config-service/src/main/java/com/wikia/mobileconfig/MobileConfigConfiguration.java
@@ -30,13 +30,11 @@ public class MobileConfigConfiguration extends Configuration {
   private String cephPort;
 
   @Valid
-  @NotNull
   @JsonProperty
   private ConsulConfig consulConfig;
 
   public MobileConfigConfiguration() {
     httpClient = new HttpClientConfiguration();
-    consulConfig = new ConsulConfig();
   }
 
   public HttpClientConfiguration getHttpClientConfiguration() {
@@ -57,5 +55,9 @@ public class MobileConfigConfiguration extends Configuration {
 
   public ConsulConfig getConsulConfig() {
     return consulConfig;
+  }
+
+  public void setConsulConfig(ConsulConfig consulConfig) {
+    this.consulConfig = consulConfig;
   }
 }

--- a/pandora-core/src/main/java/com/wikia/pandora/core/consul/ConsulBundle.java
+++ b/pandora-core/src/main/java/com/wikia/pandora/core/consul/ConsulBundle.java
@@ -64,6 +64,7 @@ public abstract class ConsulBundle<T> implements ConfiguredBundle<T> {
     ConsulConfig configuration = narrowConfig(appConfiguration);
 
     if (configuration == null) {
+      logger.warn("Missing Consul configuration - skipping Consul initialization");
       return;
     }
 

--- a/pandora-core/src/main/java/com/wikia/pandora/core/consul/ConsulBundle.java
+++ b/pandora-core/src/main/java/com/wikia/pandora/core/consul/ConsulBundle.java
@@ -62,6 +62,11 @@ public abstract class ConsulBundle<T> implements ConfiguredBundle<T> {
   @Override
   public void run(T appConfiguration, Environment environment) throws Exception {
     ConsulConfig configuration = narrowConfig(appConfiguration);
+
+    if (configuration == null) {
+      return;
+    }
+
     ConsulWrapper consul = new ConsulWrapper(configuration, environment.getName());
     environment
         .lifecycle()


### PR DESCRIPTION
@pchojnacki @nandy-andy 
Currently, we require a properly configured `ConsulConfig` instance when launching the mobile-config-service. This makes it hard to get up and running (I ran into this myself, Charles did as well, and I imagine others will too). This change allows the consulConfig portion to be missing from the configuration entirely, and only register itself with the Consul server if configured, which should be the case for local development.